### PR TITLE
Sign with claim address

### DIFF
--- a/generate_test_data.py
+++ b/generate_test_data.py
@@ -21,9 +21,9 @@ unmigrated_003 = {
     'ver': '0.0.3'
 }
 
-stream_claim_id = "76919a3572a6dcd30a63bcfb750691ea7b52dec2"
 cert_claim_id = "63f2da17b0d90042c559cc73b6b17f853945c43e"
-
+stream_claim_address = "bDtL6qriyimxz71DSYjojTBsm6cpM1bqmj"
+stream_claim_address_2 = "bUG7VaMzLEqqyZQAyg9srxQzvf1wwnJ48w"
 
 claim_010_unsigned = migrate.migrate(unmigrated_003)
 
@@ -31,7 +31,7 @@ claim_010_unsigned = migrate.migrate(unmigrated_003)
 # NIST256p test data
 nist256p_private_key = get_signer(NIST256p).generate().private_key.to_pem()
 claim_010_signed_nist256p = claim_010_unsigned.sign(nist256p_private_key,
-                                                     stream_claim_id,
+                                                     stream_claim_address,
                                                      cert_claim_id,
                                                      curve=NIST256p)
 nist256p_cert = ClaimDict.generate_certificate(nist256p_private_key, curve=NIST256p)
@@ -39,7 +39,7 @@ nist256p_cert = ClaimDict.generate_certificate(nist256p_private_key, curve=NIST2
 # NIST384p test data
 nist384p_private_key = get_signer(NIST384p).generate().private_key.to_pem()
 claim_010_signed_nist384p = claim_010_unsigned.sign(nist384p_private_key,
-                                                     stream_claim_id,
+                                                     stream_claim_address,
                                                      cert_claim_id,
                                                      curve=NIST384p)
 nist384p_cert = ClaimDict.generate_certificate(nist384p_private_key, curve=NIST384p)
@@ -47,7 +47,7 @@ nist384p_cert = ClaimDict.generate_certificate(nist384p_private_key, curve=NIST3
 # SECP256k1 test data
 secp256k1_private_key = get_signer(SECP256k1).generate().private_key.to_pem()
 claim_010_signed_secp256k1 = claim_010_unsigned.sign(secp256k1_private_key,
-                                                     stream_claim_id,
+                                                     stream_claim_address,
                                                      cert_claim_id,
                                                      curve=SECP256k1)
 secp256k1_cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
@@ -56,9 +56,12 @@ secp256k1_cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SEC
 formatted = lambda x: json.dumps(x.claim_dict, indent=2)
 
 template = """
+
 claim_id_1 = \"%s\"
 
-claim_id_2 = \"%s\"
+claim_address_2 = \"%s\"
+
+claim_address_1 = \"%s\"
 
 nist256p_private_key = \"\"\"%s\"\"\"
 
@@ -85,8 +88,9 @@ claim_010_signed_nist384p = %s
 claim_010_signed_secp256k1 = %s
 """
 
-test_data = template % (stream_claim_id,
-                        cert_claim_id,
+test_data = template % (cert_claim_id,
+                        stream_claim_address,
+                        stream_claim_address_2,
                         nist256p_private_key,
                         nist384p_private_key,
                         secp256k1_private_key,

--- a/lbryschema/claim.py
+++ b/lbryschema/claim.py
@@ -124,14 +124,14 @@ class ClaimDict(OrderedDict):
         signer = get_signer(curve).load_pem(private_key)
         return cls.load_protobuf(signer.certificate)
 
-    def sign(self, private_key, claim_id, cert_claim_id, curve=NIST256p):
+    def sign(self, private_key, claim_address, cert_claim_id, curve=NIST256p):
         signer = get_signer(curve).load_pem(private_key)
-        signed = signer.sign_stream_claim(self, claim_id, cert_claim_id)
+        signed = signer.sign_stream_claim(self, claim_address, cert_claim_id)
         return ClaimDict.load_protobuf(signed)
 
-    def validate_signature(self, claim_id, certificate):
+    def validate_signature(self, claim_address, certificate):
         if isinstance(certificate, ClaimDict):
             certificate = certificate.protobuf
         curve = CURVE_NAMES[certificate.certificate.keyType]
         validator = get_validator(curve).load_from_certificate(certificate, self.certificate_id)
-        return validator.validate_claim_signature(self, claim_id)
+        return validator.validate_claim_signature(self, claim_address)

--- a/lbryschema/signer.py
+++ b/lbryschema/signer.py
@@ -1,5 +1,6 @@
 import ecdsa
 import hashlib
+from lbryschema.base import base_decode
 from lbryschema.encoding import decode_b64_fields
 from lbryschema.schema.certificate import Certificate
 from lbryschema.schema.claim import Claim
@@ -43,11 +44,9 @@ class NIST_ECDSASigner(object):
     def generate(cls):
         return cls(ecdsa.SigningKey.generate(curve=cls.CURVE, hashfunc=cls.HASHFUNC_NAME))
 
-    def sign_stream_claim(self, claim, claim_id, cert_claim_id):
-
-        validate_claim_id(claim_id)
+    def sign_stream_claim(self, claim, claim_address, cert_claim_id):
         validate_claim_id(cert_claim_id)
-        to_sign = "%s%s%s" % (claim_id.decode('hex'),
+        to_sign = "%s%s%s" % (base_decode(claim_address, 20, 58),
                               claim.serialized_no_signature,
                               cert_claim_id.decode('hex'))
 
@@ -55,7 +54,6 @@ class NIST_ECDSASigner(object):
 
         if not isinstance(self.private_key, ecdsa.SigningKey):
             raise Exception("Not given a signing key")
-
         sig_dict = {
             "version": V_0_0_1,
             "signatureType": self.CURVE_NAME,

--- a/lbryschema/uri.py
+++ b/lbryschema/uri.py
@@ -37,6 +37,7 @@ class URI(object):
                 return False
         return self.__class__ == other.__class__
 
+    @property
     def is_channel(self):
         return self.name.startswith(CHANNEL_CHAR)
 
@@ -158,3 +159,7 @@ def get_schema_regex():
     ))
 
     return uri
+
+
+def parse_lbry_uri(lbry_uri):
+    return URI.from_uri_string(lbry_uri)

--- a/lbryschema/uri.py
+++ b/lbryschema/uri.py
@@ -1,40 +1,108 @@
 import re
-from collections import namedtuple
 from lbryschema.error import URIParseError
 
+PROTOCOL = 'lbry://'
+CHANNEL_CHAR = '@'
+CLAIM_ID_CHAR = '#'
+CLAIM_SEQUENCE_CHAR = ':'
+BID_POSITION_CHAR = '$'
+PATH_CHAR = '/'
+QUERY_CHAR = '?'
 
-def render_uri(uri_named_tuple):
-    uri_str = "lbry://%s" % uri_named_tuple.name
-    if uri_named_tuple.claim_sequence is not None:
-        uri_str += ":%i" % uri_named_tuple.claim_sequence
-    elif uri_named_tuple.bid_position is not None:
-        uri_str += "$%i" % uri_named_tuple.bid_position
-    elif uri_named_tuple.claim_id is not None:
-        uri_str += "#%s" % uri_named_tuple.claim_id
-    if uri_named_tuple.path is not None:
-        uri_str += "/%s" % uri_named_tuple.path
-    if uri_named_tuple.query is not None:
-        uri_str += "?%s" % uri_named_tuple.query
-    return uri_str
+CLAIM_ID_MAX_LENGTH = 40
+CHANNEL_NAME_MIN_LENGTH = 4
 
 
-LBRYURIType = namedtuple('URI', ['name', 'is_channel', 'claim_sequence', 'bid_position', 'claim_id',
-                             'path', 'query'])
+class URI(object):
+    __slots__ = ['name', 'claim_sequence', 'bid_position', 'claim_id', 'path']
 
+    def __init__(self, name, claim_sequence=None, bid_position=None, claim_id=None, path=None):
+        if len([v for v in [claim_sequence, bid_position, claim_id] if v is not None]) > 1:
+            raise ValueError(
+                "Only one of these may be present at a time: claim_sequence, bid_position, claim_id"
+            )
 
-class LBRYURI(LBRYURIType):
-    __slots__ = ()
-
-    def __repr__(self):
-        return render_uri(self)
+        self.name = name
+        self.claim_sequence = claim_sequence
+        self.bid_position = bid_position
+        self.claim_id = claim_id
+        self.path = path
 
     def __str__(self):
-        return render_uri(self)
+        return self.to_uri_string()
 
     def __eq__(self, other):
-        if isinstance(other, str):
-            return tuple(self) == tuple(parse_lbry_uri(other))
-        return tuple(self) == tuple(other)
+        for prop in self.__slots__:
+            if not hasattr(other, prop) or getattr(self, prop) != getattr(other, prop):
+                return False
+        return self.__class__ == other.__class__
+
+    def is_channel(self):
+        return self.name.startswith(CHANNEL_CHAR)
+
+    def to_uri_string(self):
+        uri_string = PROTOCOL + "%s" % self.name
+
+        if self.claim_sequence is not None:
+            uri_string += CLAIM_SEQUENCE_CHAR + "%i" % self.claim_sequence
+        elif self.bid_position is not None:
+            uri_string += BID_POSITION_CHAR + "%i" % self.bid_position
+        elif self.claim_id is not None:
+            uri_string += CLAIM_ID_CHAR + "%s" % self.claim_id
+
+        if self.path is not None:
+            uri_string += PATH_CHAR + "%s" % self.path
+
+        return uri_string
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            'claim_sequence': self.claim_sequence,
+            'bid_position': self.bid_position,
+            'claim_id': self.claim_id,
+            'path': self.path,
+        }
+
+    @classmethod
+    def from_uri_string(cls, uri_string):
+        """
+        Parses LBRY uri into its components
+
+        :param uri_string: format - lbry://name:n$rank#id/path
+                           optional modifiers:
+                           claim_sequence (int): the nth claim to the name
+                           bid_position (int): the bid queue position of the claim for the name
+                           claim_id (str): the claim id for the claim
+                           path (str): claim within a channel
+        :return: URI
+        """
+        match = re.match(get_schema_regex(), uri_string)
+
+        if match is None:
+            raise URIParseError('Invalid URI')
+
+        if match.group('content_name') and match.group('path'):
+            raise URIParseError('Only channels may have paths')
+
+        return cls(
+            name=match.group("content_or_channel_name"),
+            claim_sequence=int(match.group("claim_sequence")) if match.group(
+                "claim_sequence") is not None else None,
+            bid_position=int(match.group("bid_position")) if match.group(
+                "bid_position") is not None else None,
+            claim_id=match.group("claim_id"),
+            path=match.group("path")
+        )
+
+    @classmethod
+    def from_dict(cls, uri_dict):
+        """
+        Creates URI from dict
+
+        :return: URI
+        """
+        return cls(**uri_dict)
 
 
 def get_schema_regex():
@@ -44,84 +112,49 @@ def get_schema_regex():
     def _group(regex):
         return "(?:" + regex + ")"
 
-    n_char = re.escape(":")
-    claim_id_char = re.escape("#")
-    rank_char = re.escape("$")
-    channel_char = re.escape("@")
-    path_char = re.escape("/")
-    query_char = re.escape("?")
+    # Escape constants
+    claim_id_char = re.escape(CLAIM_ID_CHAR)
+    claim_sequence_char = re.escape(CLAIM_SEQUENCE_CHAR)
+    bid_position_char = re.escape(BID_POSITION_CHAR)
+    channel_char = re.escape(CHANNEL_CHAR)
+    path_char = re.escape(PATH_CHAR)
+    protocol = _named("protocol", re.escape(PROTOCOL))
 
-    claim_id_len = 40
+    # Define basic building blocks
+    valid_name_char = "[a-zA-Z0-9\-]"  # these characters are the only valid name characters
+    name_content = valid_name_char + '+'
+    name_min_channel_length = valid_name_char + '{' + str(CHANNEL_NAME_MIN_LENGTH) + ',}'
 
-    name = "[a-zA-Z0-9]+"  # expand later
     positive_number = "[1-9][0-9]*"
     number = '\-?' + positive_number
 
-    protocol = _named("protocol", re.escape("lbry://"))
-
-    content_name = _named("content_name", name)
-    channel_name = _named("channel_name", channel_char + name)
+    # Define URI components
+    content_name = _named("content_name", name_content)
+    channel_name = _named("channel_name", channel_char + name_min_channel_length)
     content_or_channel_name = _named("content_or_channel_name", content_name + "|" + channel_name)
 
-    claim_id_piece = _named("claim_id", "[0-9a-f]{1," + str(claim_id_len) + "}")
+    claim_id_piece = _named("claim_id", "[0-9a-f]{1," + str(CLAIM_ID_MAX_LENGTH) + "}")
     claim_id = _group(claim_id_char + claim_id_piece)
 
     bid_position_piece = _named("bid_position", number)
-    bid_position = _group(n_char + bid_position_piece)
+    bid_position = _group(bid_position_char + bid_position_piece)
 
     claim_sequence_piece = _named("claim_sequence", number)
-    claim_sequence = _group(rank_char + claim_sequence_piece)
+    claim_sequence = _group(claim_sequence_char + claim_sequence_piece)
 
     modifier = _named("modifier", claim_id + "|" + bid_position + "|" + claim_sequence)
 
-    path_item = _group(name)
-    path_item_cont = _group(path_char + name)
-    path_piece = _named("path", path_item + path_item_cont + '*')
+    path_piece = _named("path", name_content)
     path = _group(path_char + path_piece)
 
-    query_piece = _named("query", "[a-zA-Z0-9=&]+")
-    query = _group(query_char + query_piece)
-
+    # Combine components
     uri = _named("uri", (
         '^' +
         protocol + '?' +
         content_or_channel_name +
         modifier + '?' +
         path + '?' +
-        query + '?' +
         '$'
     ))
 
     return uri
-
-
-def parse_lbry_uri(uri_string):
-    """
-    Parser for lbry uris, only one filter (:#) may be used at a time
-
-    :param uri_string: format - lbry://name:n$rank#id/path?query
-                       optional filters:
-                       claim_sequence (int): preceded by ":", indicates the nth claim to the name
-                       bid_position (int): preceded by "$", indicates the bid queue position of the
-                                   claim for the name
-                       claim_id (str): preceded by "#", indicates the claim id for the claim
-                       path (str): preceded by "/", indicates claim within a channel
-                       query (str): preceded by "?", query to be passed to the requested claim
-    :return: URI
-    """
-
-    match = re.match(get_schema_regex(), uri_string)
-
-    if match is None:
-        raise URIParseError('Invalid URI')
-
-    uri_tuple = (
-        match.group("content_or_channel_name"),
-        True if match.group("channel_name") else False,
-        int(match.group("bid_position")) if match.group("bid_position") is not None else None,
-        int(match.group("claim_sequence")) if match.group("claim_sequence") is not None else None,
-        match.group("claim_id"),
-        match.group("path"),
-        match.group("query")
-    )
-    return LBRYURI(*uri_tuple)

--- a/lbryschema/validator.py
+++ b/lbryschema/validator.py
@@ -1,5 +1,6 @@
 import ecdsa
 import hashlib
+from lbryschema.base import base_decode
 from lbryschema.schema import NIST256p, NIST384p, SECP256k1
 
 
@@ -39,17 +40,16 @@ class Validator(object):
     def validate_signature(self, digest, signature):
         return self.public_key.verify_digest(signature, digest)
 
-    def validate_claim_signature(self, claim, claim_id):
-        # check that the claim ids provided are the 64 characters long and hex encoded
-        validate_claim_id(claim_id)
+    def validate_claim_signature(self, claim, claim_address):
+        decoded_address = base_decode(claim_address, 20, 58)
 
         # extract and serialize the stream from the claim, then check the signature
-
         signature = claim.signature.decode('hex')
+
         if signature is None:
             raise Exception("No signature to validate")
 
-        to_sign = "%s%s%s" % (claim_id.decode('hex'),
+        to_sign = "%s%s%s" % (decoded_address,
                               claim.serialized_no_signature,
                               self.certificate_claim_id.decode('hex'))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,27 +1,30 @@
 
-claim_id_1 = "76919a3572a6dcd30a63bcfb750691ea7b52dec2"
 
-claim_id_2 = "63f2da17b0d90042c559cc73b6b17f853945c43e"
+claim_id_1 = "63f2da17b0d90042c559cc73b6b17f853945c43e"
+
+claim_address_2 = "bDtL6qriyimxz71DSYjojTBsm6cpM1bqmj"
+
+claim_address_1 = "bUG7VaMzLEqqyZQAyg9srxQzvf1wwnJ48w"
 
 nist256p_private_key = """-----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIOCaUVbdv50dCmvk3mE0QF6JGmybU45qYVGT6BGAMqCVoAoGCCqGSM49
-AwEHoUQDQgAE40/hiuinR9wqJ2w/lBMN48iRSA2McQDJpDUa76M8c5Kif0cJ+Ae5
-WIAMH7V/Wr06zxQ0b7Vt+hAFT1KO4KS8Fw==
+MHcCAQEEIGomIxEhgdzuauXte1dEplhvaMNDAATmLVU1jnHjWFtToAoGCCqGSM49
+AwEHoUQDQgAEYNJiG34zcuBqhSIdcUiVqZMqneBVw0JuxLzZIHxKXaEtBx0koqB7
+rmVwhRspqHv0MZHK8S5N+48RtLuBM2Z8dw==
 -----END EC PRIVATE KEY-----
 """
 
 nist384p_private_key = """-----BEGIN EC PRIVATE KEY-----
-MIGkAgEBBDCas6kUMXDvqkbS1xlCbAsUWddKmiqXntad2fprJ7jEg4wyh6jUSf6P
-AKpz5ghmFQqgBwYFK4EEACKhZANiAATpFanGII5UsTmCwf0jDvl+Rvd3f7w9q9XU
-dDyp6Oi1Z57nKXznc7xwZ9Z6uj8GZ6/HC40Z139w2biXPIV++C70WFYjm2Lcb3L+
-4iC0ZlG5cbmoKnhKIzXjMdiX6dhMT8s=
+MIGkAgEBBDDzGJsbIL/j/leqPdsDhco6YxQRA8Dic4zzw5/YWnx66ubbc/dnM9q8
+Nq8zCgwGndagBwYFK4EEACKhZANiAAT4Jk/f7PCkodc1cPzBVpA4dzEhamBCQgRs
+6RRRRexBIm6kkphyFrWXD7AgSFzsrvtgRFiMZvy8G80QoajN3QnCjbhsJ6bbT3L/
+ww5l3R6x6clEQ0yyYmhta1yGqL76r60=
 -----END EC PRIVATE KEY-----
 """
 
 secp256k1_private_key = """-----BEGIN EC PRIVATE KEY-----
-MHQCAQEEIAxnmyRF933DWm/umfiR5y+eV4gw45B2AiRqBv/trQYZoAcGBSuBBAAK
-oUQDQgAEt3rQ9pHmyQ+ktObB4mcJmqpr+dw/isX1OBo0HnDjbJFgWIT8ypm1LzfL
-CQy/rWs8yYaZcv+ZJIbKg9ti2pmn8Q==
+MHQCAQEEIPZC9hsxKaeG450ATUUZr+LzprYOIznw5ct1FBzDv3choAcGBSuBBAAK
+oUQDQgAET2siiLU5trJ6vqyD77ZioqQ8gE7GC8MCDn+Ob3CeANdvT4G2joeTPkEJ
+aavGq7zZ++ZsXBIjg//2p1UqXcDQNA==
 -----END EC PRIVATE KEY-----
 """
 
@@ -29,7 +32,7 @@ nist256p_cert = {
   "version": "_0_0_1", 
   "claimType": "certificateType", 
   "certificate": {
-    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d03010703420004e34fe18ae8a747dc2a276c3f94130de3c891480d8c7100c9a4351aefa33c7392a27f4709f807b958800c1fb57f5abd3acf14346fb56dfa10054f528ee0a4bc17", 
+    "publicKey": "3059301306072a8648ce3d020106082a8648ce3d0301070342000460d2621b7e3372e06a85221d714895a9932a9de055c3426ec4bcd9207c4a5da12d071d24a2a07bae6570851b29a87bf43191caf12e4dfb8f11b4bb8133667c77", 
     "keyType": "NIST256p", 
     "version": "_0_0_1"
   }
@@ -39,7 +42,7 @@ nist384p_cert = {
   "version": "_0_0_1", 
   "claimType": "certificateType", 
   "certificate": {
-    "publicKey": "3076301006072a8648ce3d020106052b8104002203620004e915a9c6208e54b13982c1fd230ef97e46f7777fbc3dabd5d4743ca9e8e8b5679ee7297ce773bc7067d67aba3f0667afc70b8d19d77f70d9b8973c857ef82ef45856239b62dc6f72fee220b46651b971b9a82a784a2335e331d897e9d84c4fcb", 
+    "publicKey": "3076301006072a8648ce3d020106052b8104002203620004f8264fdfecf0a4a1d73570fcc15690387731216a604242046ce9145145ec41226ea492987216b5970fb020485cecaefb6044588c66fcbc1bcd10a1a8cddd09c28db86c27a6db4f72ffc30e65dd1eb1e9c944434cb262686d6b5c86a8befaafad", 
     "keyType": "NIST384p", 
     "version": "_0_0_1"
   }
@@ -49,7 +52,7 @@ secp256k1_cert = {
   "version": "_0_0_1", 
   "claimType": "certificateType", 
   "certificate": {
-    "publicKey": "3056301006072a8648ce3d020106052b8104000a03420004b77ad0f691e6c90fa4b4e6c1e267099aaa6bf9dc3f8ac5f5381a341e70e36c91605884fcca99b52f37cb090cbfad6b3cc9869972ff992486ca83db62da99a7f1", 
+    "publicKey": "3056301006072a8648ce3d020106052b8104000a034200044f6b2288b539b6b27abeac83efb662a2a43c804ec60bc3020e7f8e6f709e00d76f4f81b68e87933e410969abc6abbcd9fbe66c5c122383fff6a7552a5dc0d034", 
     "keyType": "SECP256k1", 
     "version": "_0_0_1"
   }
@@ -104,7 +107,7 @@ claim_010_signed_nist256p = {
     "certificateId": "63f2da17b0d90042c559cc73b6b17f853945c43e", 
     "signatureType": "NIST256p", 
     "version": "_0_0_1", 
-    "signature": "a8ca9aaab647c2e84297726a224d5c8849dc52ecd935160114b7d975c99c113f8f1e0a62e2081af998f9e86bc9c856b0282666b938646a6494417a76947dceed"
+    "signature": "de693b07b28a1981d8c4edec3f8902386953f4fbe8d89ff35037ca22cc9a862793254435d0f2f2d7412378e08a69070597088ffe8a6fd3a85c03e17ec1b9243c"
   }, 
   "claimType": "streamType", 
   "stream": {
@@ -136,7 +139,7 @@ claim_010_signed_nist384p = {
     "certificateId": "63f2da17b0d90042c559cc73b6b17f853945c43e", 
     "signatureType": "NIST384p", 
     "version": "_0_0_1", 
-    "signature": "a0a3d3004be0ca0433309b15ea2ddfee6cd1664b87b53136f0d00a8843c49d6a0caebf18432f7258c44341a4af01c074628c267629523798cf499552d196b10535af3973c506c332bcbb91b634fe5bab1594bb504e5fc8d42405aa848b350e98"
+    "signature": "051de53fb07db8b3522f70b586f25379afde28c2e645aab39b3211db034cbabc70dd76ca105f7fcc9e4d8af699250e62412f5b98bd8930ed76eaeacf0465afff605b18cb6379188864a69787de60e456fc283c566d35a5dcdc4cd5c9661c17e7"
   }, 
   "claimType": "streamType", 
   "stream": {
@@ -168,7 +171,7 @@ claim_010_signed_secp256k1 = {
     "certificateId": "63f2da17b0d90042c559cc73b6b17f853945c43e", 
     "signatureType": "SECP256k1", 
     "version": "_0_0_1", 
-    "signature": "af4604eeb8f99da60c2f27c9554ae6164de3e579b6c0f6e2767b5d7c8bc66814fd6d69ebca69dcd30c35b721a6148d04906861412975a712d2ded341c987d70b"
+    "signature": "0def4b70f2af92020b0bd3b8ce73df3067d7b315d40d5c82045af8bc9acf817bb49640a5a6081874d81f2b56065d1065a2bf69471cbb01b4589226179f8b2f41"
   }, 
   "claimType": "streamType", 
   "stream": {

--- a/tests/test_lbryschema.py
+++ b/tests/test_lbryschema.py
@@ -87,7 +87,7 @@ class TestURIParser(UnitTest):
             self.assertEquals(URI.from_dict(expected_uri_obj.to_dict()), expected_uri_obj,
                               test_string)
             # is_channel
-            self.assertEquals(URI.from_uri_string(test_string).is_channel(), is_channel,
+            self.assertEquals(URI.from_uri_string(test_string).is_channel, is_channel,
                               test_string)
 
             # convert-to-string test only works if protocol is present in test_string

--- a/tests/test_lbryschema.py
+++ b/tests/test_lbryschema.py
@@ -5,7 +5,8 @@ import ecdsa
 from copy import deepcopy
 import unittest
 
-from test_data import example_003, example_010, example_010_serialized, claim_id_1, claim_id_2
+from test_data import example_003, example_010, example_010_serialized
+from test_data import claim_id_1, claim_address_1, claim_address_2
 from test_data import nist256p_private_key, claim_010_signed_nist256p, nist256p_cert
 from test_data import nist384p_private_key, claim_010_signed_nist384p, nist384p_cert
 from test_data import secp256k1_private_key, claim_010_signed_secp256k1, secp256k1_cert
@@ -149,34 +150,34 @@ class TestNIST256pSignatures(UnitTest):
     def test_validate_ecdsa_signature(self):
         cert = ClaimDict.generate_certificate(nist256p_private_key, curve=NIST256p)
         signed = ClaimDict.load_dict(example_010).sign(nist256p_private_key,
-                                                       claim_id_1, claim_id_2, curve=NIST256p)
+                                                       claim_address_1, claim_id_1, curve=NIST256p)
         self.assertDictEqual(signed.claim_dict, claim_010_signed_nist256p)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
-        self.assertEquals(signed_copy.validate_signature(claim_id_1, cert), True)
+        self.assertEquals(signed_copy.validate_signature(claim_address_1, cert), True)
 
     def test_remove_signature_equals_unsigned(self):
         unsigned = ClaimDict.load_dict(example_010)
-        signed = unsigned.sign(nist256p_private_key, claim_id_1, claim_id_2, curve=NIST256p)
+        signed = unsigned.sign(nist256p_private_key, claim_address_1, claim_id_1, curve=NIST256p)
         self.assertEquals(unsigned.serialized, signed.serialized_no_signature)
 
     def test_fail_to_validate_fake_ecdsa_signature(self):
-        signed = ClaimDict.load_dict(example_010).sign(nist256p_private_key, claim_id_1,
-                                                       claim_id_2, curve=NIST256p)
+        signed = ClaimDict.load_dict(example_010).sign(nist256p_private_key, claim_address_1,
+                                                       claim_id_1, curve=NIST256p)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
         fake_key = get_signer(NIST256p).generate().private_key.to_pem()
         fake_cert = ClaimDict.generate_certificate(fake_key, curve=NIST256p)
         self.assertRaises(ecdsa.keys.BadSignatureError, signed_copy.validate_signature,
-                          claim_id_1, fake_cert)
+                          claim_address_2, fake_cert)
 
     def test_fail_to_validate_ecdsa_sig_for_altered_claim(self):
         cert = ClaimDict.generate_certificate(nist256p_private_key, curve=NIST256p)
-        altered = ClaimDict.load_dict(example_010).sign(nist256p_private_key, claim_id_1,
-                                                        claim_id_2, curve=NIST256p)
+        altered = ClaimDict.load_dict(example_010).sign(nist256p_private_key, claim_address_1,
+                                                        claim_id_1, curve=NIST256p)
         sd_hash = altered['stream']['source']['source']
         altered['stream']['source']['source'] = sd_hash[::-1]
         altered_copy = ClaimDict.load_dict(altered.claim_dict)
         self.assertRaises(ecdsa.keys.BadSignatureError, altered_copy.validate_signature,
-                          claim_id_1, cert)
+                          claim_address_1, cert)
 
 
 class TestNIST384pSignatures(UnitTest):
@@ -188,34 +189,34 @@ class TestNIST384pSignatures(UnitTest):
     def test_validate_ecdsa_signature(self):
         cert = ClaimDict.generate_certificate(nist384p_private_key, curve=NIST384p)
         signed = ClaimDict.load_dict(example_010).sign(nist384p_private_key,
-                                                       claim_id_1, claim_id_2, curve=NIST384p)
+                                                       claim_address_1, claim_id_1, curve=NIST384p)
         self.assertDictEqual(signed.claim_dict, claim_010_signed_nist384p)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
-        self.assertEquals(signed_copy.validate_signature(claim_id_1, cert), True)
+        self.assertEquals(signed_copy.validate_signature(claim_address_1, cert), True)
 
     def test_remove_signature_equals_unsigned(self):
         unsigned = ClaimDict.load_dict(example_010)
-        signed = unsigned.sign(nist384p_private_key, claim_id_1, claim_id_2, curve=NIST384p)
+        signed = unsigned.sign(nist384p_private_key, claim_address_1, claim_id_1, curve=NIST384p)
         self.assertEquals(unsigned.serialized, signed.serialized_no_signature)
 
     def test_fail_to_validate_fake_ecdsa_signature(self):
-        signed = ClaimDict.load_dict(example_010).sign(nist384p_private_key, claim_id_1,
-                                                       claim_id_2, curve=NIST384p)
+        signed = ClaimDict.load_dict(example_010).sign(nist384p_private_key, claim_address_1,
+                                                       claim_id_1, curve=NIST384p)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
         fake_key = get_signer(NIST384p).generate().private_key.to_pem()
         fake_cert = ClaimDict.generate_certificate(fake_key, curve=NIST384p)
         self.assertRaises(ecdsa.keys.BadSignatureError, signed_copy.validate_signature,
-                          claim_id_1, fake_cert)
+                          claim_address_2, fake_cert)
 
     def test_fail_to_validate_ecdsa_sig_for_altered_claim(self):
         cert = ClaimDict.generate_certificate(nist384p_private_key, curve=NIST384p)
-        altered = ClaimDict.load_dict(example_010).sign(nist384p_private_key, claim_id_1,
-                                                        claim_id_2, curve=NIST384p)
+        altered = ClaimDict.load_dict(example_010).sign(nist384p_private_key, claim_address_1,
+                                                        claim_id_1, curve=NIST384p)
         sd_hash = altered['stream']['source']['source']
         altered['stream']['source']['source'] = sd_hash[::-1]
         altered_copy = ClaimDict.load_dict(altered.claim_dict)
         self.assertRaises(ecdsa.keys.BadSignatureError, altered_copy.validate_signature,
-                          claim_id_1, cert)
+                          claim_address_1, cert)
 
 
 class TestSECP256k1Signatures(UnitTest):
@@ -227,34 +228,34 @@ class TestSECP256k1Signatures(UnitTest):
     def test_validate_ecdsa_signature(self):
         cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
         signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key,
-                                                       claim_id_1, claim_id_2, curve=SECP256k1)
+                                                       claim_address_1, claim_id_1, curve=SECP256k1)
         self.assertDictEqual(signed.claim_dict, claim_010_signed_secp256k1)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
-        self.assertEquals(signed_copy.validate_signature(claim_id_1, cert), True)
+        self.assertEquals(signed_copy.validate_signature(claim_address_1, cert), True)
 
     def test_remove_signature_equals_unsigned(self):
         unsigned = ClaimDict.load_dict(example_010)
-        signed = unsigned.sign(secp256k1_private_key, claim_id_1, claim_id_2, curve=SECP256k1)
+        signed = unsigned.sign(secp256k1_private_key, claim_address_1, claim_id_1, curve=SECP256k1)
         self.assertEquals(unsigned.serialized, signed.serialized_no_signature)
 
     def test_fail_to_validate_fake_ecdsa_signature(self):
-        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_id_1,
-                                                       claim_id_2, curve=SECP256k1)
+        signed = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_1,
+                                                       claim_id_1, curve=SECP256k1)
         signed_copy = ClaimDict.load_protobuf(signed.protobuf)
         fake_key = get_signer(SECP256k1).generate().private_key.to_pem()
         fake_cert = ClaimDict.generate_certificate(fake_key, curve=SECP256k1)
         self.assertRaises(ecdsa.keys.BadSignatureError, signed_copy.validate_signature,
-                          claim_id_1, fake_cert)
+                          claim_address_2, fake_cert)
 
     def test_fail_to_validate_ecdsa_sig_for_altered_claim(self):
         cert = ClaimDict.generate_certificate(secp256k1_private_key, curve=SECP256k1)
-        altered = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_id_1,
-                                                        claim_id_2, curve=SECP256k1)
+        altered = ClaimDict.load_dict(example_010).sign(secp256k1_private_key, claim_address_1,
+                                                        claim_id_1, curve=SECP256k1)
         sd_hash = altered['stream']['source']['source']
         altered['stream']['source']['source'] = sd_hash[::-1]
         altered_copy = ClaimDict.load_dict(altered.claim_dict)
         self.assertRaises(ecdsa.keys.BadSignatureError, altered_copy.validate_signature,
-                          claim_id_1, cert)
+                          claim_address_1, cert)
 
 
 class TestMetadata(UnitTest):


### PR DESCRIPTION
When signing using the claim id, only claims from the first update and on
can be signed, as the claim id can’t be known and included in the
signature until after the initial claim has been made.

The address of a claim is known when building the transaction - so it can be included in the signature of a name claim to the same effect without needing a second (first update) transaction.