### PR TITLE
verify certificate curve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ labeled as 2.7.1. Subsequent releases will follow
   *
 
 ### Fixed
-  *
+  * Verify that a Certificate keyType matches that in the der encoded public key
   *
 
 ### Deprecated

--- a/lbryschema/validator.py
+++ b/lbryschema/validator.py
@@ -12,11 +12,14 @@ def validate_claim_id(claim_id):
 
 
 class Validator(object):
+    CURVE_NAME = None
     HASHFUNC = hashlib.sha256
 
     def __init__(self, public_key, certificate_claim_id):
         if not isinstance(public_key, ecdsa.VerifyingKey):
             raise Exception("Key is not type needed for verification")
+        if not self.CURVE_NAME == public_key.curve.name:
+            raise Exception("Curve mismatch")
         self._public_key = public_key
         self._certificate_claim_id = certificate_claim_id
 
@@ -57,14 +60,17 @@ class Validator(object):
 
 
 class NIST256pValidator(Validator):
+    CURVE_NAME = NIST256p
     HASHFUNC = hashlib.sha256
 
 
 class NIST384pValidator(Validator):
+    CURVE_NAME = NIST384p
     HASHFUNC = hashlib.sha384
 
 
 class SECP256k1Validator(Validator):
+    CURVE_NAME = SECP256k1
     HASHFUNC = hashlib.sha256
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -58,6 +58,16 @@ secp256k1_cert = {
   }
 }
 
+malformed_secp256k1_cert = {
+  "version": "_0_0_1",
+  "claimType": "certificateType",
+  "certificate": {
+    "publicKey": "3056301006072a8648ce3d020106052b8104000a0342000494b3eb91521aa6fb4aaefd0392041bf6f017b42403048bbe88796c402e5dc75667396670a58290b8ce222cd6ee4e57f1087598c28bf02e36276a8f22c20a74a2",
+    "keyType": "NIST256p",
+    "version": "_0_0_1"
+  }
+}
+
 example_003 = {
   "language": "en", 
   "license": "LBRY Inc", 

--- a/tests/test_lbryschema.py
+++ b/tests/test_lbryschema.py
@@ -10,7 +10,7 @@ from test_data import claim_id_1, claim_address_1, claim_address_2
 from test_data import nist256p_private_key, claim_010_signed_nist256p, nist256p_cert
 from test_data import nist384p_private_key, claim_010_signed_nist384p, nist384p_cert
 from test_data import secp256k1_private_key, claim_010_signed_secp256k1, secp256k1_cert
-from test_data import hex_encoded_003, decoded_hex_encoded_003
+from test_data import hex_encoded_003, decoded_hex_encoded_003, malformed_secp256k1_cert
 from lbryschema.claim import ClaimDict
 from lbryschema.schema import NIST256p, NIST384p, SECP256k1
 from lbryschema.legacy.migrate import migrate
@@ -360,6 +360,12 @@ class TestAddressValidation(UnitTest):
     def test_address_decode_error(self):
         with self.assertRaises(InvalidAddress):
             decode_address("bW5PZEvEBNPQRVhwpYXSjabFgbSw1oaHR")
+
+
+class TestInvalidCertificateCurve(UnitTest):
+    def test_invalid_cert_curve(self):
+        with self.assertRaises(Exception):
+            ClaimDict.load_dict(malformed_secp256k1_cert)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
{
 "version": "_0_0_1",
  "claimType": "certificateType",
  "certificate": {
    "publicKey": "3056301006072a8648ce3d020106052b8104000a0342000494b3eb91521aa6fb4aaefd0392041bf6f017b42403048bbe88796c402e5dc75667396670a58290b8ce222cd6ee4e57f1087598c28bf02e36276a8f22c20a74a2",
    "keyType": "NIST256p",
    "version": "_0_0_1"
  }
}
```

A certificate like the above is currently decoded without an error - but an error should be raised because the public key is for secp256k1 but the curve asserted is nist256p. This adds validation to ensure the curves match.