### PR TITLE
Bump jsonschema version to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 protobuf==3.2.0
-jsonschema==2.5.1
+jsonschema==2.6.0
 ecdsa==0.13

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from lbryschema import __version__ as version
 
 requires = [
     'protobuf==3.2.0',
-    'jsonschema==2.5.1',
+    'jsonschema',
     'ecdsa==0.13',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ import os
 from lbryschema import __version__ as version
 
 requires = [
-    'protobuf==3.2.0',
+    'protobuf',
     'jsonschema',
-    'ecdsa==0.13',
+    'ecdsa',
 ]
 
 base_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "lbryschema")


### PR DESCRIPTION
Bump jsonschema version to 2.6.0,
Also removed the tagged versions number for requirements on setup.py as they are not necessary.

https://packaging.python.org/discussions/install-requires-vs-requirements/